### PR TITLE
37 read in database redis information from commandline

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,22 +1,11 @@
 {
-  "UserService": {
-    "port": 8000,
-    "ip": "dh2020pc26.utm.utoronto.ca"
-  },
-  "ProductService": {
-    "port": 9000,
-    "ip": "dh2020pc26.utm.utoronto.ca"
-  },
-  "OrderService": {
-    "port": 7998,
-    "ip": "dh2020pc29.utm.utoronto.ca"
-  },
-  "InterServiceCommunication": {
-    "port": 7999,
-    "ip": "dh2020pc29.utm.utoronto.ca"
-  },
-  "Database": {
-    "port": 5434,
-    "ip": "142.1.46.61"
-  }
+  "docker": 142.1.44.57,
+  "db_port": 5432,
+  "rd_port": 6379,
+  "user": ["ip1", "ip2", "ip3"],
+  "user_port": 8000,
+  "product": ["ip1", "ip2", "ip3"],
+  "product_port": 8001,
+  "order": ["ip1", "ip2", "ip3"],
+  "order_port": 8002
 }

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -5,8 +5,3 @@ FROM postgres:latest
 ENV POSTGRES_DB=assignmentdb
 ENV POSTGRES_USER=assignmentuser
 ENV POSTGRES_PASSWORD=assignmentpassword
-
-# Copt SQL script to init the database
-# Make sure the script is called init.sql
-# Once hte script is created, uncomment the line below
-# COPY init.sql /docker-entrypoint-initdb.d/

--- a/database/README.md
+++ b/database/README.md
@@ -1,29 +1,15 @@
-# Dockerized Database Setup
+# Docker
+
+**NOTE: These scripts can only be run from the csc301 VM located at the port specified on Piazza.**
 
 ## Docker setup
 
-To setup the database, a Dockerfile was created to create an instance of the database. The docker:
+There are two shell scripts in this directory:
 
-1. Chooses the latest version of PostgreSQL
-2. Sets the database, user, and password of the database
-3. Copies the file that initially sets up the database to the necessary location
+- `start_docker.sh`: This script will start the docker containers for both the database and the redis cache.
+- `kill_docker.sh`: This script will stop the docker containers for both the database and the redis cache.
 
-## Script setup
+## Running the scripts
 
-The runme_db.sh script will run two commands:
-
-1. Command to create the docker image (if image is created then no issue)
-2. Command to run the docker image
-
-## Run the script
-
-To run the script, make sure that the script has the correct permissions to run. Do this by running:
-
-```chmod +x runme_db.sh```
-
-Verify permissions by running:
-
-```ls -larth runme_db.sh```
-
-Finally, run the command:
-```./runme_db.sh```
+- Ensure that the scripts are executable by running `chmod +x start_docker.sh kill_docker.sh`.
+- Alternatively, run `bash start_docker.sh` and `bash kill_docker.sh`.

--- a/database/connect_to_db.sh
+++ b/database/connect_to_db.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "The password is asignmentpassword"
+psql -h 142.1.44.57 -p 5432 -U assignmentuser -d assignmentdb

--- a/database/connect_to_db.sh
+++ b/database/connect_to_db.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-echo "The password is asignmentpassword"
+echo "The password is assignmentpassword"
 psql -h 142.1.44.57 -p 5432 -U assignmentuser -d assignmentdb

--- a/database/kill_docker.sh
+++ b/database/kill_docker.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if containers are running
+if [ $(docker ps -q | wc -l) -eq 0 ]; then
+    echo "No containers are running"
+    exit 0
+fi
+
 # Stop all running container
 docker stop $(docker ps -q)
 

--- a/database/kill_docker.sh
+++ b/database/kill_docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Stop all running container
+docker stop $(docker ps -q)
+
+# Remove all stopped containers
+docker rm $(docker ps -aq)

--- a/database/kill_docker.sh
+++ b/database/kill_docker.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check that we're running on the school VM
+# We can check the ip using curl ipinfo.io/ip
+# It must equal 142.1.44.57
+if [ $(curl -s ipinfo.io/ip) != "142.1.44.57" ]; then
+    echo "You are not running on the school VM"
+    exit 1
+fi
+
 # Check if containers are running
 if [ $(docker ps -q | wc -l) -eq 0 ]; then
     echo "No containers are running"

--- a/database/postgres/Dockerfile
+++ b/database/postgres/Dockerfile
@@ -5,3 +5,9 @@ FROM postgres:latest
 ENV POSTGRES_DB=assignmentdb
 ENV POSTGRES_USER=assignmentuser
 ENV POSTGRES_PASSWORD=assignmentpassword
+
+# Copy postgresql.conf to container
+COPY ./postgresql.conf /etc/postgresql/postgresql.conf
+
+# Expose Port
+EXPOSE 5432

--- a/database/postgres/postgresql.conf
+++ b/database/postgres/postgresql.conf
@@ -1,0 +1,12 @@
+# Custom postgreSQL configuration to enable concurrent connections and multithreading
+
+# Set the maximum number of concurrent connections
+max_connections = 100
+
+# Set the number of concurrent connections that can be used for multithreading
+# This is set to 2x the number of CPU cores
+max_worker_processes = 16
+
+# Enable parallel query execution
+max_parallel_workers_per_gather = 8
+max_parallel_workers = 16

--- a/database/redis/Dockerfile
+++ b/database/redis/Dockerfile
@@ -1,0 +1,2 @@
+# Use latest Version
+FROM redis:latest

--- a/database/runme_db.sh
+++ b/database/runme_db.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker build -t assignmentpostgres .
-docker run -d --name assignmentpostgrescontainer -p 5432:5432 assignmentpostgres

--- a/database/start_docker.sh
+++ b/database/start_docker.sh
@@ -17,7 +17,7 @@ fi
 
 
 # Build postgres, Build redis
-docker build -t assignmentpostgres .
+docker build -t assignmentpostgres ./postgres/
 docker build -t assignmentredis ./redis/
 
 # Run postgres

--- a/database/start_docker.sh
+++ b/database/start_docker.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# First, check that containers are not running
+# If they are, tell user to run stop_docker.sh
+if [ "$(docker ps -q -f name=assignmentpostgrescontainer)" ]; then
+    echo "Containers are already running. Please run kill_docker.sh first."
+    exit 1
+fi
+
+
 # Build postgres, Build redis
 docker build -t assignmentpostgres .
 docker build -t assignmentredis ./redis/

--- a/database/start_docker.sh
+++ b/database/start_docker.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check that we're running on the school VM
+# We can check the ip using curl ipinfo.io/ip
+# It must equal 142.1.44.57
+if [ $(curl -s ipinfo.io/ip) != "142.1.44.57" ]; then
+    echo "You are not running on the school VM"
+    exit 1
+fi
+
 # First, check that containers are not running
 # If they are, tell user to run stop_docker.sh
 if [ "$(docker ps -q -f name=assignmentpostgrescontainer)" ]; then

--- a/database/start_docker.sh
+++ b/database/start_docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Build postgres, Build redis
+docker build -t assignmentpostgres .
+docker build -t assignmentredis ./redis/
+
+# Run postgres
+docker run -d --name assignmentpostgrescontainer -p 5432:5432 assignmentpostgres
+# Run redis
+docker run -d --name assignmentrediscontainer assignmentredis
+
+

--- a/runme.sh
+++ b/runme.sh
@@ -43,7 +43,10 @@ start_us() {
 start_ps() {
 	# Run the product service with the product port
 	PRODUCT_PORT=$1
-	java -cp "$script_dir/compiled/ProductService:$script_dir/compiled/json-20231013.jar:$script_dir/compiled/postgresql-42.7.2.jar" ProductService "$PRODUCT_PORT"
+	DOCKER_IP=$2
+	DB_PORT=$3
+	RD_PORT=$4
+	java -cp "$script_dir/compiled/ProductService:$script_dir/compiled/json-20231013.jar:$script_dir/compiled/postgresql-42.7.2.jar" ProductService "$PRODUCT_PORT" "$DOCKER_IP" "$DB_PORT" "$RD_PORT"
 }
 
 # Function to start the OrderService
@@ -86,10 +89,10 @@ case "$1" in
         compile_code
         ;;
     -u)
-        start_us "$2"
+        start_us "$2" "$3" "$4" "$5"
         ;;
     -p)
-        start_ps "$2"
+        start_ps "$2" "$3" "$4" "$5"
         ;;
     -i)
 	start_iscs "$2"

--- a/runme.sh
+++ b/runme.sh
@@ -33,7 +33,10 @@ compile_code() {
 start_us() {
 	# run the user service with the user port
 	USER_PORT=$1
-	java -cp "$script_dir/compiled/UserService:$script_dir/compiled/json-20231013.jar:$script_dir/compiled/postgresql-42.7.2.jar" UserService "$USER_PORT"
+	DOCKER_IP=$2
+	DB_PORT=$3
+	RD_PORT=$4
+	java -cp "$script_dir/compiled/UserService:$script_dir/compiled/json-20231013.jar:$script_dir/compiled/postgresql-42.7.2.jar" UserService "$USER_PORT" "$DOCKER_IP" "$DB_PORT" "$RD_PORT"
 }
 
 # Function to start the ProductService

--- a/src/OrderService/OrderDatabase.java
+++ b/src/OrderService/OrderDatabase.java
@@ -51,7 +51,7 @@ class OrderDatabase {
             statement.execute(sql);
         }
         catch (SQLException e) {
-            //(e.getMessage());
+	    System.out.println(e.getMessage());
         }
     }
 

--- a/src/OrderService/OrderDatabase.java
+++ b/src/OrderService/OrderDatabase.java
@@ -11,17 +11,10 @@ import org.json.JSONObject;
 
 class OrderDatabase {
 
-    private static final String url = "jdbc:postgresql://142.1.46.61:5434/assignmentdb";
+    public static String url = "jdbc:postgresql://142.1.44.57:5432/assignmentdb";
     private static final String user = "assignmentuser";
     private static final String password = "assignmentpassword";
 
-
-    /**
-     * Constructor for the UserDatabase. This method initializes the database using the initialize().
-     */
-    public OrderDatabase() {
-        initialize();
-    }
 
     /**
      * The connect method is used to establish a connection to the SQLite database.
@@ -30,9 +23,10 @@ class OrderDatabase {
     private Connection connect() {
         Connection con = null;
         try {
+	    // TODO: Add REDIS connection
             con = DriverManager.getConnection(url, user, password);
         } catch (SQLException e) {
-            //(e.getMessage());
+            System.out.println(e.getMessage());
         }
         return con;
     }
@@ -41,7 +35,8 @@ class OrderDatabase {
      * The initialize method which is used in the constructor is for initializing the database by creating a table
      * for users if it does not already exist.
      */
-    public void initialize() {
+    public void initialize(String dockerIp, String dbPort, String redisPort) {
+	url = "jdbc:postgresql://" + dockerIp + ":" + dbPort + "/assignmentdb";
         try (Connection con = connect();
             Statement statement = con.createStatement()) {
             String sql = "CREATE TABLE IF NOT EXISTS orders (" +
@@ -52,7 +47,7 @@ class OrderDatabase {
                     "FOREIGN KEY (user_id) REFERENCES users(id) " +
                     "ON DELETE CASCADE, " +
                     "FOREIGN KEY (prod_id) REFERENCES products(id) " +
-                    "ON DELETE CASCADE)";
+                    "ON DELETE CASCADE)"; // TODO: This is not supposed to cascade (we want to see deleted users order history)
             statement.execute(sql);
         }
         catch (SQLException e) {

--- a/src/OrderService/OrderService.java
+++ b/src/OrderService/OrderService.java
@@ -95,14 +95,14 @@ public class OrderService
                     //Initialize variables
                     String orderData = OrderService.getRequestBody(exchange);
                     JSONObject jsonObject = new JSONObject(orderData);
-                    String status_message = "Invalid Request";
 
                     //Verify that all fields are present for creation
                     if (!(jsonObject.has("product_id")
                             && jsonObject.has("user_id")
                             && jsonObject.has("quantity")))
                     {
-                        sendResponse(exchange, 400, "{\"status\": \"Invalid Request\"}");
+			jsonObject.put("status", "Invalid Request");
+                        sendResponse(exchange, 400, jsonObject.toString());
                         exchange.close();
                         return;
                     }
@@ -113,21 +113,23 @@ public class OrderService
 
                     if (orderDB.getUser(userID).equals("") || orderDB.getProduct(prodID).equals("")) {
                         // Send a 405 Method Not Allowed response for non-POST requests
-                        sendResponse(exchange, 400, "{\"status\": \"Invalid Request\"}");
+			jsonObject.put("status", "Invalid Request");
+                        sendResponse(exchange, 400, jsonObject.toString());
                     }
 
                     JSONObject product = new JSONObject(orderDB.getProduct(prodID));
                     int newQuantity = product.getInt("quantity") - quantity;
                     if (newQuantity < 0) {
                         // Send a 405 Method Not Allowed response for non-POST requests
-                        sendResponse(exchange, 400, "{\"status\": \"Exceeded quantity limit\"}");
+			jsonObject.put("status", "Invalid Request");
+			sendResponse(exchange, 400, jsonObject.toString());
                     	return;
 		    }
 
 		    int statusCode = orderDB.placeOrder(userID, prodID, quantity, newQuantity);
 
                     if (statusCode != 200) {
-                        jsonObject.put("status", status_message);
+                        jsonObject.put("status", "Invalid Request");
                     } else {
                         jsonObject.put("status", "Success"); // TEST
                     }

--- a/src/OrderService/OrderService.java
+++ b/src/OrderService/OrderService.java
@@ -87,14 +87,26 @@ public class OrderService
         @Override
         public void handle(HttpExchange exchange) throws IOException
         {
+            //Initialize variables
+            String orderData = OrderService.getRequestBody(exchange);
+            JSONObject jsonObject = new JSONObject(orderData);
             try
             {
+
                 // Handle POST request for /order
                 if ("POST".equals(exchange.getRequestMethod()))
                 {
-                    //Initialize variables
-                    String orderData = OrderService.getRequestBody(exchange);
-                    JSONObject jsonObject = new JSONObject(orderData);
+
+		    // Check that the command is "place order"
+		    if (!jsonObject.has("command") || !jsonObject.getString("command").equals("place order")) {
+			jsonObject.put("status", "Invalid Request");
+			// Remove the command from the JSON object
+			jsonObject.remove("command");
+			sendResponse(exchange, 400, jsonObject.toString());
+		    }
+		    // Remove the command from the JSON object
+		    jsonObject.remove("command");
+
 
                     //Verify that all fields are present for creation
                     if (!(jsonObject.has("product_id")
@@ -141,7 +153,8 @@ public class OrderService
             catch (Exception e)
             {
                 // If something weird happens, we send a 400 error code representing an invalid HTTP request
-                sendResponse(exchange, 400, "{\"status\": \"Invalid Request\"}");
+		jsonObject.put("status", "Invalid Request");
+                sendResponse(exchange, 400, jsonObject.toString());
             }
             exchange.close();
         }

--- a/src/ProductService/ProductDatabase.java
+++ b/src/ProductService/ProductDatabase.java
@@ -4,25 +4,18 @@ import java.sql.*;
  * UserDatabase class provides methods for managing user data in a SQLite database.
  */
 public class ProductDatabase {
-    private final String url = "jdbc:postgresql://142.1.46.61:5434/assignmentdb";
+    public static String url = "jdbc:postgresql://142.1.44.57:5432/assignmentdb";
     private final String user = "assignmentuser";
     private final String password = "assignmentpassword";
 
     /**
-     * Constructor for the UserDatabase. This method initializes the database using the initialize().
-     */
-    public ProductDatabase() {
-        initialize();
-    }
-
-    /**
-     * The connect method is used to establish a connection to the SQLite database.
-     *
+     * The connect method is used to establish a connection to the database.
      * @return value is a connection object to the SQLite database.
      */
     private Connection connect() {
         Connection con = null;
         try {
+	    // TODO: Add REDIS connection
             con = DriverManager.getConnection(url, user, password);
         } catch (SQLException e) {
             //(e.getMessage());
@@ -33,8 +26,12 @@ public class ProductDatabase {
     /**
      * The initialize method which is used in the constructor is for initializing the database by creating a table
      * for users if it does not already exist.
+     * @param dockerIp is the IP address of the Docker container running the database.
+     * @param dbPort is the port number of the database.
+     * @param redisPort is the port number of the Redis server.
      */
-    private void initialize() {
+    public void initialize(String dockerIp, String dbPort, String redisPort) {
+	url = "jdbc:postgresql://" + dockerIp + ":" + dbPort + "/assignmentdb";
         try (Connection con = connect();
              Statement statement = con.createStatement()) {
             String sql = "CREATE TABLE IF NOT EXISTS products (" +
@@ -45,7 +42,7 @@ public class ProductDatabase {
                     "quantity INTEGER NOT NULL)";
             statement.execute(sql);
         } catch (SQLException e) {
-            //(e.getMessage());
+            System.out.println(e.getMessage());
         }
     }
 
@@ -196,4 +193,3 @@ public class ProductDatabase {
 
 
 }
-

--- a/src/ProductService/ProductDatabase.java
+++ b/src/ProductService/ProductDatabase.java
@@ -18,7 +18,7 @@ public class ProductDatabase {
 	    // TODO: Add REDIS connection
             con = DriverManager.getConnection(url, user, password);
         } catch (SQLException e) {
-            //(e.getMessage());
+            System.out.println(e.getMessage());
         }
         return con;
     }

--- a/src/ProductService/ProductService.java
+++ b/src/ProductService/ProductService.java
@@ -32,19 +32,23 @@ public class ProductService
     public static void main(String[] args) throws IOException
     {
         String ip = "0.0.0.0";
-        int port = -1;
+	String dockerIp, dbPort, redisPort;
+        int port;
 
-        // Get port from the command line
-        if (args.length > 0)
+        // Get port to listen on
+	// Get docker ip
+	// Get db port
+	// Get redis port
+	if (args.length != 4)
         {
-            port = Integer.parseInt(args[0]);
-        }
-        else
-        {
-            //("No command-line arguments provided.");
+            System.out.println("Missing arguments <port> <dockerIp> <dbPort> <redisPort>");
             System.exit(1);
         }
 
+        port = Integer.parseInt(args[0]);
+	dockerIp = args[1];
+	dbPort = args[2];
+	redisPort = args[3];
 
         HttpServer server = HttpServer.create(new InetSocketAddress(ip, port), 0);
         // Example: Set a custom executor with a fixed-size thread pool
@@ -56,12 +60,18 @@ public class ProductService
         // Set up context for a GET request
         server.createContext("/product/", new GetHandler());
 
-
         server.setExecutor(null); // creates a default executor
+
+	// Initialize the database with docker IP and ports
+	productDB.initialize(dockerIp, dbPort, redisPort);
 
         server.start();
 
-        //("Server started on port " + port);
+	System.out.println("Product Service is running on port " + port);
+	System.out.println("Docker IP: " + dockerIp);
+	System.out.println("DB Port: " + dbPort);
+	System.out.println("Redis Port: " + redisPort);
+
     }
 
     /**

--- a/src/ProductService/ProductService.java
+++ b/src/ProductService/ProductService.java
@@ -312,10 +312,23 @@ public class ProductService
      */
     public static void sendResponse(HttpExchange exchange, int rCode, String response) throws IOException
     {
-        exchange.sendResponseHeaders(rCode, response.length());
-        OutputStream os = exchange.getResponseBody();
-        os.write(response.getBytes(StandardCharsets.UTF_8));
-        os.close();
+//        exchange.sendResponseHeaders(rCode, response.length());
+//        OutputStream os = exchange.getResponseBody();
+//        os.write(response.getBytes(StandardCharsets.UTF_8));
+//        os.close();
+        // Convert the response String to bytes to correctly measure its length in bytes
+        byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
+
+        // Set the necessary response headers before sending the response body
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+
+        // Correctly set the content length using the byte length of the response
+        exchange.sendResponseHeaders(rCode, responseBytes.length);
+
+        // Write the response bytes and close the OutputStream
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(responseBytes);
+        }
     }
 
     /**

--- a/src/ProductService/ProductService.java
+++ b/src/ProductService/ProductService.java
@@ -298,7 +298,6 @@ public class ProductService
                 //If any weird error occurs, then ProductService has received a bad http request
                 sendResponse(exchange, 400, new JSONObject().toString());
             }
-            exchange.close();
         }
     }
 

--- a/src/UserService/UserDatabase.java
+++ b/src/UserService/UserDatabase.java
@@ -10,25 +10,21 @@ import java.sql.*;
 
 class UserDatabase {
 
-    private final String url = "jdbc:postgresql://142.1.46.61:5434/assignmentdb";
+    private String url = "jdbc:postgresql://142.1.44.57:5432/assignmentdb";
     private final String user = "assignmentuser";
     private final String password = "assignmentpassword";
 
-
-    /**
-     * Constructor for the UserDatabase. This method initializes the database using the initialize().
-     */
-    public UserDatabase() {
-        initialize();
-    }
-
     /**
      * The connect method is used to establish a connection to the SQLite database.
+     * @param dockerIp is the IP address of the Docker container running the database.
+     * @param dbPort is the port number of the database.
+     * @param redisPort is the port number of the Redis server.
      * @return value is a connection object to the SQLite database.
      */
     private Connection connect() {
         Connection con = null;
         try {
+	    // TODO: Add REDIS connection
             con = DriverManager.getConnection(url, user, password);
         } catch (SQLException e) {
             //(e.getMessage());
@@ -40,7 +36,8 @@ class UserDatabase {
      * The initialize method which is used in the constructor is for initializing the database by creating a table
      * for users if it does not already exist.
      */
-    public void initialize() {
+    public void initialize(String dockerIp, String dbPort, String redisPort) {
+	url = "jdbc:postgresql://" + dockerIp + ":" + dbPort + "/assignmentdb";
         try (Connection con = connect();
              Statement statement = con.createStatement()) {
             String sql = "CREATE TABLE IF NOT EXISTS users (" +

--- a/src/UserService/UserDatabase.java
+++ b/src/UserService/UserDatabase.java
@@ -10,7 +10,7 @@ import java.sql.*;
 
 class UserDatabase {
 
-    private String url = "jdbc:postgresql://142.1.44.57:5432/assignmentdb";
+    public static String url = "jdbc:postgresql://142.1.44.57:5432/assignmentdb";
     private final String user = "assignmentuser";
     private final String password = "assignmentpassword";
 

--- a/src/UserService/UserDatabase.java
+++ b/src/UserService/UserDatabase.java
@@ -27,7 +27,7 @@ class UserDatabase {
 	    // TODO: Add REDIS connection
             con = DriverManager.getConnection(url, user, password);
         } catch (SQLException e) {
-            //(e.getMessage());
+            System.out.println(e.getMessage());
         }
         return con;
     }

--- a/src/UserService/UserDatabase.java
+++ b/src/UserService/UserDatabase.java
@@ -15,10 +15,7 @@ class UserDatabase {
     private final String password = "assignmentpassword";
 
     /**
-     * The connect method is used to establish a connection to the SQLite database.
-     * @param dockerIp is the IP address of the Docker container running the database.
-     * @param dbPort is the port number of the database.
-     * @param redisPort is the port number of the Redis server.
+     * The connect method is used to establish a connection to the database.
      * @return value is a connection object to the SQLite database.
      */
     private Connection connect() {
@@ -35,6 +32,9 @@ class UserDatabase {
     /**
      * The initialize method which is used in the constructor is for initializing the database by creating a table
      * for users if it does not already exist.
+     * @param dockerIp is the IP address of the Docker container running the database.
+     * @param dbPort is the port number of the database.
+     * @param redisPort is the port number of the Redis server.
      */
     public void initialize(String dockerIp, String dbPort, String redisPort) {
 	url = "jdbc:postgresql://" + dockerIp + ":" + dbPort + "/assignmentdb";

--- a/src/UserService/UserDatabase.java
+++ b/src/UserService/UserDatabase.java
@@ -49,7 +49,7 @@ class UserDatabase {
             statement.execute(sql);
         }
         catch (SQLException e) {
-            //(e.getMessage());
+            System.out.println(e.getMessage());
         }
     }
 

--- a/src/UserService/UserService.java
+++ b/src/UserService/UserService.java
@@ -63,7 +63,7 @@ public class UserService
 
         server.setExecutor(null); // creates a default executor
 
-	// Initialize the database
+	// Initialize the database with docker IP and ports
 	userDB.initialize(dockerIp, dbPort, redisPort);
 
         server.start();

--- a/src/UserService/UserService.java
+++ b/src/UserService/UserService.java
@@ -65,7 +65,10 @@ public class UserService
 
         server.start();
 
-        //("Server started on port " + port);
+        System.out.println("UserService is listening on port " + port);
+	System.out.println("Docker IP: " + dockerIp);
+	System.out.println("DB Port: " + dbPort);
+	System.out.println("Redis Port: " + redisPort);
 
     }
 

--- a/src/UserService/UserService.java
+++ b/src/UserService/UserService.java
@@ -27,25 +27,29 @@ public class UserService
     /**
      * The main method for the UserService application. Starts an HTTP server to handle user-related requests.
      *
-     * @param args Command-line arguments. Expects an absolute working directory path as the first argument.
+     * @param args Command-line arguments. The first argument is the port number to listen on. The second argument is the IP address of the Docker container running the database. The third argument is the port number of the database. The fourth argument is the port number of the Redis server.
      * @throws IOException If an I/O error occurs during the initialization or execution of the server.
      */
     public static void main(String[] args) throws IOException
     {
         String ip = "0.0.0.0";
-        int port = -1;
+	String dockerIp;
+        int port, dbPort, redisPort;
 
-        // Get port from the command line
-        if (args.length > 0)
+        // Get port to listen on
+	// Get docker ip
+	// Get db port
+	// Get redis port
+	if (args.length != 4)
         {
-            port = Integer.parseInt(args[0]);
-        }
-        else
-        {
-            //("No command-line arguments provided.");
+            System.out.println("Missing arguments <port> <dockerIp> <dbPort> <redisPort>");
             System.exit(1);
         }
 
+        port = Integer.parseInt(args[0]);
+	dockerIp = args[1];
+	dbPort = Integer.parseInt(args[2]);
+	redisPort = Integer.parseInt(args[3]);
 
         HttpServer server = HttpServer.create(new InetSocketAddress(ip, port), 0);
         // Example: Set a custom executor with a fixed-size thread pool

--- a/src/UserService/UserService.java
+++ b/src/UserService/UserService.java
@@ -33,8 +33,8 @@ public class UserService
     public static void main(String[] args) throws IOException
     {
         String ip = "0.0.0.0";
-	String dockerIp;
-        int port, dbPort, redisPort;
+	String dockerIp, dbPort, redisPort;
+        int port;
 
         // Get port to listen on
 	// Get docker ip
@@ -48,8 +48,8 @@ public class UserService
 
         port = Integer.parseInt(args[0]);
 	dockerIp = args[1];
-	dbPort = Integer.parseInt(args[2]);
-	redisPort = Integer.parseInt(args[3]);
+	dbPort = args[2];
+	redisPort = args[3];
 
         HttpServer server = HttpServer.create(new InetSocketAddress(ip, port), 0);
         // Example: Set a custom executor with a fixed-size thread pool
@@ -62,6 +62,9 @@ public class UserService
         server.createContext("/user/", new GetHandler());
 
         server.setExecutor(null); // creates a default executor
+
+	// Initialize the database
+	userDB.initialize(dockerIp, dbPort, redisPort);
 
         server.start();
 


### PR DESCRIPTION
- [x] {User,Order,Product}Services read in the following from the commandline:
  ```
  <port> <docker IP> <postgres port> <redis port>
  ```
- [x] The dockerized database now runs a 16 threaded instance and can handle concurrent querying (for an 8 core VM (according to `nproc`) 16 threads)
- [x] The docker can now run on the labs' `csc301` virtual machine, with very limited changes
- [x] Creation of a dockerized redis cache on the `csc301` virtual machine
- [x] Various bug fixes in {User,Order,Product}Service:
  - Response is now always sent back as `JSON`
  - `/order` endpoint follows API docs

Closes #37, #36, #34, #18
# TODO:
- Add Redis Interactions to existing Database classes
- OrderService fixes (just the removal of the other endpoints)
- `runme.sh` enhancements
- Stress Tests & Documentation + Submission
  - Look into the demo times whenever they show up.