### PR TITLE
created startservices.sh

### DIFF
--- a/killservices.sh
+++ b/killservices.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Absolute path of the directory containing the script
+script_dir=$(dirname "$(readlink -f "$0")")
+
+# Directory containing logs
+logs_dir="$script_dir/logs"
+
+# Function to kill services
+kill_services() {
+    local service="$1"
+    local pattern="${service}_*"
+    
+    # Find all log files matching the service pattern
+    log_files=$(find "$logs_dir" -maxdepth 1 -name "$pattern")
+
+    # Loop through log files and extract PIDs to kill
+    for log_file in $log_files; do
+        pid=$(grep -oP '\b[0-9]+(?=\.[lL][oO][gG])' <<< "$log_file")
+        if [ -n "$pid" ]; then
+            echo "Killing service with PID: $pid"
+            kill "$pid"
+        fi
+    done
+}
+
+# Main script
+case "$1" in
+    -u)
+        kill_services "user"
+        ;;
+    -p)
+        kill_services "product"
+        ;;
+    -o)
+        kill_services "order"
+        ;;
+    *)
+        echo "Usage: $0 { -u | -p | -o }"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/runme.sh
+++ b/runme.sh
@@ -89,7 +89,7 @@ case "$1" in
         start_ps "$2" "$3" "$4" "$5"
         ;;
     -i)
-	start_iscs "$2"
+	    start_iscs "$2"
         ;;
     -o)
         start_os "$2" "$3" "$4"
@@ -98,7 +98,7 @@ case "$1" in
         start_wg "$2"
 	;;
     -d)
-	start_db
+	    start_db
 	;;
     *)
         echo "Usage: $0 { -c | -d | -u port | -p port | -i port | -o port | -w workloadfile }"

--- a/startservices.sh
+++ b/startservices.sh
@@ -11,7 +11,6 @@ mkdir -p "$logs_dir"
 
 # Local username and password for SSH
 username="your_username"
-password="your_password"
 
 # Function to start the specified service
 start_service() {
@@ -26,7 +25,7 @@ start_service() {
     for ip in "${ips[@]}"; do
         service_log="$logs_dir/${service}_${ip}_${port}.log"
         echo "Starting $service service on $ip:$port..."
-        sshpass -p "$password" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$username@$ip" "bash $script_dir/runme.sh $command $port $docker_ip $db_port $rd_port" >> "$service_log" 2>&1 &
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$username@$ip" "bash $script_dir/runme.sh $command $port $docker_ip $db_port $rd_port" >> "$service_log" 2>&1 &
     done
 }
 

--- a/startservices.sh
+++ b/startservices.sh
@@ -15,7 +15,8 @@ password="your_password"
 
 # Function to start the specified service
 start_service() {
-    local service="$1"
+    local command="$1"
+    local service="$2"
     local port=$(jq -r ".$service" "$script_dir/config.json" | jq -r '.port')
     local docker_ip=$(jq -r '.docker' "$script_dir/config.json")
     local db_port=$(jq -r '.db_port' "$script_dir/config.json")
@@ -25,7 +26,7 @@ start_service() {
     for ip in "${ips[@]}"; do
         service_log="$logs_dir/${service}_${ip}_${port}.log"
         echo "Starting $service service on $ip:$port..."
-        sshpass -p "$password" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$username@$ip" "bash $script_dir/runme.sh -$service $port $docker_ip $db_port $rd_port" >> "$service_log" 2>&1 &
+        sshpass -p "$password" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$username@$ip" "bash $script_dir/runme.sh $command $port $docker_ip $db_port $rd_port" >> "$service_log" 2>&1 &
     done
 }
 
@@ -35,13 +36,13 @@ case "$1" in
         bash "$script_dir/runme.sh" -c
         ;;
     -u)
-        start_service "user"
+        start_service "-u" "user"
         ;;
     -p)
-        start_service "product"
+        start_service "-p" "product"
         ;;
     -o)
-        start_service "order"
+        start_service "-o" "order"
         ;;
     *)
         echo "Usage: $0 { -c | -u | -p | -o }"

--- a/startservices.sh
+++ b/startservices.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Absolute path of the directory containing this script
+script_dir=$(dirname "$(readlink -f "$0")")
+
+# Directory to store logs
+logs_dir="$script_dir/logs"
+
+# Create the logs directory if it doesn't exist
+mkdir -p "$logs_dir"
+
+# Local username and password for SSH
+username="your_username"
+password="your_password"
+
+# Function to start the specified service
+start_service() {
+    local service="$1"
+    local port=$(jq -r ".$service" "$script_dir/config.json" | jq -r '.port')
+    local docker_ip=$(jq -r '.docker' "$script_dir/config.json")
+    local db_port=$(jq -r '.db_port' "$script_dir/config.json")
+    local rd_port=$(jq -r '.rd_port' "$script_dir/config.json")
+    local ips=($(jq -r ".$service[]" "$script_dir/config.json"))
+
+    for ip in "${ips[@]}"; do
+        service_log="$logs_dir/${service}_${ip}_${port}.log"
+        echo "Starting $service service on $ip:$port..."
+        sshpass -p "$password" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$username@$ip" "bash $script_dir/runme.sh -$service $port $docker_ip $db_port $rd_port" >> "$service_log" 2>&1 &
+    done
+}
+
+# Main script
+case "$1" in
+    -c)
+        bash "$script_dir/runme.sh" -c
+        ;;
+    -u)
+        start_service "user"
+        ;;
+    -p)
+        start_service "product"
+        ;;
+    -o)
+        start_service "order"
+        ;;
+    *)
+        echo "Usage: $0 { -c | -u | -p | -o }"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/startservices.sh
+++ b/startservices.sh
@@ -17,11 +17,11 @@ password="your_password"
 start_service() {
     local command="$1"
     local service="$2"
-    local port=$(jq -r ".$service" "$script_dir/config.json" | jq -r '.port')
-    local docker_ip=$(jq -r '.docker' "$script_dir/config.json")
-    local db_port=$(jq -r '.db_port' "$script_dir/config.json")
-    local rd_port=$(jq -r '.rd_port' "$script_dir/config.json")
-    local ips=($(jq -r ".$service[]" "$script_dir/config.json"))
+    local port=$(grep -oP "\"$service\":\s*\K\d+" "$script_dir/config.json")
+    local docker_ip=$(grep -oP "\"docker\":\s*\"\K[^\" ]+" "$script_dir/config.json")
+    local db_port=$(grep -oP "\"db_port\":\s*\K\d+" "$script_dir/config.json")
+    local rd_port=$(grep -oP "\"rd_port\":\s*\K\d+" "$script_dir/config.json")
+    local ips=($(grep -oP "\"$service\":\s*\[\s*\K[^\]]+" "$script_dir/config.json" | grep -oP "\d+\.\d+\.\d+\.\d+"))
 
     for ip in "${ips[@]}"; do
         service_log="$logs_dir/${service}_${ip}_${port}.log"


### PR DESCRIPTION
Modified indentation of runme.sh file.

Created a new bash script that starts the user, product and order services iteratively.

All outputs from the ssh will be redirected to a logs folder

ssh to each ip that is specified in the config.json file, start running the service on the port in the background, exit and repeat in a for loop

The username and password must be specified from beforehand in the startservices script

Note: I'm using jq to parse the config.json file. I'm not sure if this bash command is installed on lab machines

- Update: I removed sshpass since it is not secure. You'll have to set up a key value pair as follows before running the script:

ssh-keygen -t rsa -b 4096
ssh-copy-id username@your_server_ip

- Update 2: Added a kill script to kill all services through the log files.